### PR TITLE
Changes for plugin deactivate event

### DIFF
--- a/includes/admin/class-simpl-checkout-settings.php
+++ b/includes/admin/class-simpl-checkout-settings.php
@@ -168,21 +168,11 @@ class WC_Simpl_Settings {
 			$event_data = array(
 				"merchant_id" => $simpl_host,
 			);
-			$event_payload = array(
-				"trigger_timestamp" => time(),
-				"event_name" => "Update settings",
-				"event_data" => array_merge($event_data, self::latest_settings()),
-				"entity" =>  "Manage settings",
-				"flow" => "Merchant woocommerce-admin page"
-			);
-
-
-			$simplHttpResponse = wp_remote_post("https://".$simpl_host."/api/v1/wc/publish/events", array(
-				"body" => json_encode($event_payload),
-				"headers" => array(            
-						"content-type" => "application/json"
-					),
-			)); 
+			$event_name = "Update settings";
+			$event_data = array_merge($event_data, self::latest_settings());
+			$entity = "Manage settings";
+			$flow = "Merchant woocommerce-admin page";
+			$simplHttpResponse = SimplWcEventHelper::publish_event($event_name, $event_data, $entity, $flow);
 			if (!is_wp_error($simplHttpResponse)) {
 				$body = json_decode( wp_remote_retrieve_body( $simplHttpResponse ), true );
 			} else {

--- a/includes/admin/plugin-action-hook.php
+++ b/includes/admin/plugin-action-hook.php
@@ -4,6 +4,23 @@ function my_plugin_activate() {
 }
 
 function my_plugin_deactivate() {
-    wp_remote_get("https://webhook.site/15d3a3ef-58bc-41bc-9633-0e9f19593c69?deactivate=true");
+    $simpl_host = WC_Simpl_Settings::simpl_host();
+    $current_user = wp_get_current_user();
+    $email = $current_user->user_email;
+    $admin = $current_user->user_login;
+    $event_name = "Update Plugin";
+    $entity = "Manage Plugin";
+    $flow = "woocommerce-admin plugin page";
+    $event_data = array(
+        "merchant_id" => $simpl_host,
+        "action" => "plugin deactivate",
+        "user" => $admin,
+        "email" => $email
+    );
+    $simplHttpResponse = SimplWcEventHelper::publish_event($event_name, $event_data, $entity, $flow);
+    if (is_wp_error($simplHttpResponse)) {
+        $error_message = $simplHttpResponse->get_error_message();
+        simpl_sentry_exception($error_message);
+    }
 }
 ?>

--- a/includes/helpers/class-simpl-wc-helper.php
+++ b/includes/helpers/class-simpl-wc-helper.php
@@ -206,3 +206,23 @@ function updateToSimplDraft($orderId) {
     ));
 }
 
+
+class SimplWcEventHelper {
+    static function publish_event($event_name, $event_data, $entity, $flow) {
+        $simpl_host = WC_Simpl_Settings::simpl_host();
+        $event_payload = array(
+            "trigger_timestamp" => time(),
+            "event_name" => $event_name,
+            "event_data" => $event_data,
+            "entity" =>  $entity,
+            "flow" => $flow
+        );
+        $simplHttpResponse = wp_remote_post("https://".$simpl_host."/api/v1/wc/publish/events", array(
+            "body" => json_encode($event_payload),
+            "headers" => array(            
+                    "content-type" => "application/json"
+                ),
+        )); 
+        return $simplHttpResponse;
+    }
+}


### PR DESCRIPTION
On plugin deactivation an event will be published
Sample Event :
` 
{
   "entity": "Manage Plugin",
   "event_data": {
      "action": "plugin deactivate",
      "email": "saurabh.singh@getsimpl.com",
      "merchant_id": "checkout-3pp.stagingsimpl.com",
      "user": "admin"
   },
   "event_id": "7b397e56-0d79-4cea-89a2-15247b5669aa",
   "event_name": "Update Plugin",
   "event_namespace": "checkout_3pp",
   "event_timestamp": "2023-05-26 10:21:10.460411",
   "event_type": "Admin::Events",
   "flow": "woocommerce-admin plugin page",
   "origin": {
      "service": "woocommerce-backend",
      "squad": "checkout-3pp"
   },
   "trigger_timestamp": 1685340551,
   "version": "1.0.0"
}`