### PR TITLE
Fix: Tax Based on Shipping Address

### DIFF
--- a/includes/helpers/class-simpl-wc-helper.php
+++ b/includes/helpers/class-simpl-wc-helper.php
@@ -93,6 +93,12 @@ class SimplWcCartHelper {
             throw new SimplCustomHttpBadRequest("country is not supported");
         }
         $address["country"] = $supported_cc;
+
+        $supported_sc = SimplUtil::state_code_for_state($address["state"]);
+        if(!isset($supported_sc)) {
+            throw new SimplCustomHttpBadRequest("state is not supported");
+        }
+        $address["state"] = $supported_sc;
     
         return  $address;
     }

--- a/includes/utils/load.php
+++ b/includes/utils/load.php
@@ -13,9 +13,21 @@ class SimplUtil
         return $supported_states[$state_name];
     }
 
+    static function state_name_from_code($state_code)
+    {
+        $states = WC()->countries->get_states("IN");
+        return $states[$state_code];
+    }
+
     static function country_code_for_country($country_name)
     {
         $supported_countries = array("india" => "IN");
         return $supported_countries[strtolower($country_name)];
+    }
+
+    static function country_name_from_code($country_code)
+    {
+        $supported_countries = array("IN" => "India");
+        return $supported_countries[$country_code];
     }
 }


### PR DESCRIPTION
Bug: Amounts were different in PDP and in our iframe
Fix: Converting state name to state code before storing in woo-commerce so that state-based taxes can be applied on checkout and our totals match with the store's totals