### PR TITLE
order type update for Woocommerce

### DIFF
--- a/includes/endpoints/internal/class-simpl-checkout-order-controller.php
+++ b/includes/endpoints/internal/class-simpl-checkout-order-controller.php
@@ -66,7 +66,7 @@ class SimplCheckoutOrderController
             $order->set_payment_method('cod');
             $order->set_payment_method_title('Cash on delivery');
         } else {
-            $order->set_payment_method($request->get_params()["simpl_payment_type"]);
+            $order->set_payment_method('Simpl Checkout');
             $order->set_payment_method_title($request->get_params()["simpl_payment_type"]);
         }
         $order->save();

--- a/includes/endpoints/internal/class-simpl-checkout-order-controller.php
+++ b/includes/endpoints/internal/class-simpl-checkout-order-controller.php
@@ -66,7 +66,7 @@ class SimplCheckoutOrderController
             $order->set_payment_method('cod');
             $order->set_payment_method_title('Cash on delivery');
         } else {
-            $order->set_payment_method('simpl_checkout_payment');
+            $order->set_payment_method($request->get_params()["simpl_payment_type"]);
             $order->set_payment_method_title($request->get_params()["simpl_payment_type"]);
         }
         $order->save();

--- a/simpl-checkout-woocommerce.php
+++ b/simpl-checkout-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: Simpl checkout offers an optimised checkout process, higher order conversions and RTO reduction. We offer Simpl Pay Later, Pay-in-3, UPI, Cards, and COD for seamless transactions while you focus on growing your business.
  * Author:  One Sigma Technologies Pvt. Ltd.
  * Author URI: http://www.getsimpl.com
- * Version: 1.0
+ * Version: 1.1.1
  */
 add_action('plugins_loaded', 'simpl_checkout_int', 0);
 add_filter( 'woocommerce_payment_gateways', 'simpl_add_gateway_class' );


### PR DESCRIPTION
Previously on particular order on Woocommerce apart from cod it shows **'.'**  now the issue is fixed.

Previously
<img width="406" alt="Screenshot 2023-08-23 at 12 41 25 PM" src="https://github.com/GetSimpl/simpl-checkout-woocommerce/assets/140687002/9c097f8c-1549-4e10-874f-44667cf1559e">

Now
<img width="554" alt="Screenshot 2023-08-23 at 12 42 02 PM" src="https://github.com/GetSimpl/simpl-checkout-woocommerce/assets/140687002/20b7d6f9-e7d6-45ba-a79b-966b791d53d7">

