### PR TITLE
PF-175-xtremenutrition-error-on-null-session

### DIFF
--- a/includes/helpers/utils.php
+++ b/includes/helpers/utils.php
@@ -1,12 +1,16 @@
 <?php
 
 function get_unique_device_id() {
-	$unique_device_id = WC()->session->get("simpl:session:id") ?: "";
-	return $unique_device_id;
+	if(WC()->session) {
+		return WC()->session->get("simpl:session:id");
+	}
+	return "";
 }
 
 function set_unique_device_id($unique_device_id){
-	WC()->session->set("simpl:session:id", $unique_device_id);
+	if(WC()->session) {
+		WC()->session->set("simpl:session:id", $unique_device_id);
+	}
 }
 
 ?>


### PR DESCRIPTION
get_unique_device_id breaks when session is null